### PR TITLE
Port is not required since it should be already included in rules

### DIFF
--- a/src/components/UrlManager.php
+++ b/src/components/UrlManager.php
@@ -140,7 +140,7 @@ class UrlManager extends BaseUrlManager
         if ($this->forcePort !== null) {
             $port = $this->forcePort === 80 ? '' : ':' . $this->forcePort;
         } else {
-            $port = Yii::$app->request->port === 80 ? '' : ':' . Yii::$app->request->port;
+            $port = '';
         }
         return $scheme . '://' . $rules['domain'] . $port . '/' . ltrim($url, '/');
     }


### PR DESCRIPTION
Basically the problem comes when you use a port number in the domain (on context and language definitions). You have to specify it there to make the components work properly (as I have tested so far). Otherwise, GetLanguageByUrl will not work properly and an exception will raise on the UrlManager component.

Having said that, you will run into problems when generating language URLs since port will be specified twice in the final URL (one coming from the rules domain field, the other coming from the port of the request itself).